### PR TITLE
Adding OTEL tracing and metrics to the app

### DIFF
--- a/Gifytools/Diagnostics/GifyMetrics.cs
+++ b/Gifytools/Diagnostics/GifyMetrics.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Gifytools.Diagnostics
+{
+
+    public class GifyMetrics
+    {
+        public static ActivitySource GifytoolsActivitySource = new("Gifytools", typeof(GifyMetrics).Assembly.GetName().Version?.ToString());
+
+        private readonly Counter<int> _gifsCreated;
+        private readonly Histogram<double> _sizeHistogram;
+        private readonly UpDownCounter<int> _currentJobs;
+
+        public GifyMetrics(IMeterFactory meterFactory)
+        {
+            var meter = meterFactory.Create("Gifytools");
+            _gifsCreated = meter.CreateCounter<int>("gifytools.gifs.created", description: "Counts how many gifs were created");
+            _sizeHistogram = meter.CreateHistogram<double>("gifytools.gifs.size", unit: "byte", description: "Records how big the converted videos are");
+            _currentJobs = meter.CreateUpDownCounter<int>("gifytools.jobs.running", description: "The current number of conversion jobs running");
+        }
+
+        public void GifCreated()
+        {
+            _gifsCreated.Add(1);
+        }
+
+        public void VideoUploaded(double sizeOfVideo)
+        {
+            _sizeHistogram.Record(sizeOfVideo);
+        }
+
+        public void JobStarted()
+        {
+            _currentJobs.Add(1);
+        }
+
+        public void JobFinished()
+        {
+            _currentJobs.Add(-1);
+        }
+    }
+}

--- a/Gifytools/Gifytools.csproj
+++ b/Gifytools/Gifytools.csproj
@@ -8,11 +8,18 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="9.0.7" />
+		<PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.12.0-beta.1" />
 		<PackageReference Include="Plantup.Swagger" Version="1.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
 		<PackageReference Include="Plantup.Hangfire" Version="1.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.7" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/Gifytools/Gifytools.csproj
+++ b/Gifytools/Gifytools.csproj
@@ -11,6 +11,7 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="9.0.7" />
 		<PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
 		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.12.0-beta.1" />

--- a/Gifytools/Jobs/AutomaticDeletionJob.cs
+++ b/Gifytools/Jobs/AutomaticDeletionJob.cs
@@ -11,10 +11,12 @@ public class AutomaticDeletionJob : IRecurringJob
 {
 
     private readonly AppDbContext _appDbContext;
+    private readonly ILogger<AutomaticDeletionJob> _logger;
 
-    public AutomaticDeletionJob(AppDbContext appDbContext)
+    public AutomaticDeletionJob(AppDbContext appDbContext, ILogger<AutomaticDeletionJob> logger)
     {
         _appDbContext = appDbContext;
+        _logger = logger;
     }
 
     public void Execute(PerformContext context)
@@ -24,6 +26,7 @@ public class AutomaticDeletionJob : IRecurringJob
 
     public async Task ExecuteAsync(PerformContext context)
     {
+        _logger.LogInformation("Executing job {job}", nameof(AutomaticDeletionJob));
         const int daysToKeep = 7;
 
         var conversionRequests = await _appDbContext.ConversionRequests
@@ -47,6 +50,7 @@ public class AutomaticDeletionJob : IRecurringJob
             }
             catch(Exception ex)
             {
+                _logger.LogError(ex, "Error deleting files for {conversionRequest}", conversionRequest.Id);
                 context.WriteLine($"Failed to delete files for conversion request {conversionRequest.Id}. Because of {ex.Message} {ex.InnerException}");
             }
 

--- a/Gifytools/ProcessQueue/GifConversionWorker.cs
+++ b/Gifytools/ProcessQueue/GifConversionWorker.cs
@@ -1,7 +1,7 @@
 ﻿using Gifytools.Bll;
 using Gifytools.Database;
 using Gifytools.Database.Entities;
-using Hangfire;
+using Gifytools.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gifytools.ProcessQueue;
@@ -9,29 +9,41 @@ public class GifConversionWorker
 {
     private readonly AppDbContext _appDbContext;
     private readonly IVideoToGifService _videoToGif;
+    private readonly GifyMetrics _metrics;
+    private readonly ILogger<GifConversionWorker> _logger;
 
-    public GifConversionWorker(AppDbContext appDbContext, IVideoToGifService videoToGif)
+    public GifConversionWorker(AppDbContext appDbContext, IVideoToGifService videoToGif, GifyMetrics metrics, ILogger<GifConversionWorker> logger)
     {
         _appDbContext = appDbContext;
         _videoToGif = videoToGif;
+        _metrics = metrics;
+        _logger = logger;
     }
     
     public async Task Execute(Guid conversionRequestId)
     {
+        using var activity = GifyMetrics.GifytoolsActivitySource.StartActivity("Gifytools.Convert");
+        activity?.SetCustomProperty(nameof(conversionRequestId), conversionRequestId);
+        _logger.LogInformation("Started conversion with request id {conversionRequest}", conversionRequestId);
         var conversionRequest = await _appDbContext.ConversionRequests.FirstAsync(x => x.Id == conversionRequestId);
-
+        _metrics.JobStarted();
         try
         {
             var gifPath = await _videoToGif.ConvertToGif(conversionRequest);
             conversionRequest.GifOutputPath = gifPath;
             conversionRequest.ConversionStatus = ConversionStatusEnum.Completed;
+            _logger.LogInformation("Conversion {conversionRequest} done", conversionRequest);
+            _metrics.GifCreated();
+            activity?.SetStatus(System.Diagnostics.ActivityStatusCode.Ok);
         }
         catch (Exception e)
         {
             conversionRequest.ConversionStatus = ConversionStatusEnum.Failed;
             conversionRequest.ErrorMessage = e.Message;
+            _logger.LogError(e, "Error while converting video for request {conversionRequest}", conversionRequest);
+            activity?.SetStatus(System.Diagnostics.ActivityStatusCode.Error);
         }
-
+        _metrics.JobFinished();
         conversionRequest.ExecutedDate = DateTime.UtcNow;
         
         await _appDbContext.SaveChangesAsync();

--- a/Gifytools/Program.cs
+++ b/Gifytools/Program.cs
@@ -4,6 +4,7 @@ using Gifytools.Diagnostics;
 using Gifytools.Settings;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -38,21 +39,28 @@ builder.Logging.AddOpenTelemetry(logging =>
     logging.IncludeScopes = true;
 });
 
-//Add OpenTelemetry to have some nice stats from our apps to view in something like grafana
+//Add OpenTelemetry to have some nice stats from our apps to view in something like the Aspire dashboard
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(resource => resource.AddService("Gifytools", serviceVersion: "1.0.0")) //set the service name of our app
+    .WithLogging(logging => 
+        logging
+            .AddConsoleExporter()
+            .AddOtlpExporter())
     .WithTracing(tracing => 
         tracing
             .AddAspNetCoreInstrumentation() //collect default asp.net core traces
             .AddHangfireInstrumentation() //collect hangfire traces
             .AddNpgsql() //collect npgsql traces
             .AddSource("Gifytools") //collect our own traces
-            .AddConsoleExporter()) //export them to console
+            .AddConsoleExporter() //export them to console (for local usage)
+            .AddOtlpExporter()) //and export them using the OTLP format - you could use this to view the logs and metrics with the Aspire dashboard (see https://learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-otlp-example)
     .WithMetrics(metrics => 
          metrics
             .AddAspNetCoreInstrumentation() //add default asp.net core meters
             .AddNpgsqlInstrumentation() //add npgsql meters
-            .AddMeter("Gifytools")); //add our meters
+            .AddMeter("Gifytools")//add our meters
+            .AddConsoleExporter()
+            .AddOtlpExporter()); 
 
 builder.Services.AddSingleton<GifyMetrics>();
 

--- a/Gifytools/Program.cs
+++ b/Gifytools/Program.cs
@@ -1,12 +1,17 @@
 using Gifytools.Bll;
 using Gifytools.Database;
-using Gifytools.ProcessQueue;
+using Gifytools.Diagnostics;
 using Gifytools.Settings;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Plantup.Hangfire.Hangfire;
 using Plantup.Swagger.Swagger;
 
 var builder = WebApplication.CreateBuilder(args);
+
 
 // Add services to the container.
 builder.Services.AddCors(options =>
@@ -19,6 +24,37 @@ builder.Services.AddCors(options =>
                 .AllowAnyMethod(); 
         });
 });
+
+//Add Systemd to configure logging in Systemd format and also do some other nice stuff to integrate is as a service
+builder.Host.UseSystemd();
+
+//add some logging to get away from Console.WriteLine()
+builder.Logging.AddConsole();
+
+//also add our logs to our OTEL endpoint
+builder.Logging.AddOpenTelemetry(logging =>
+{
+    logging.IncludeFormattedMessage = true;
+    logging.IncludeScopes = true;
+});
+
+//Add OpenTelemetry to have some nice stats from our apps to view in something like grafana
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("Gifytools", serviceVersion: "1.0.0")) //set the service name of our app
+    .WithTracing(tracing => 
+        tracing
+            .AddAspNetCoreInstrumentation() //collect default asp.net core traces
+            .AddHangfireInstrumentation() //collect hangfire traces
+            .AddNpgsql() //collect npgsql traces
+            .AddSource("Gifytools") //collect our own traces
+            .AddConsoleExporter()) //export them to console
+    .WithMetrics(metrics => 
+         metrics
+            .AddAspNetCoreInstrumentation() //add default asp.net core meters
+            .AddNpgsqlInstrumentation() //add npgsql meters
+            .AddMeter("Gifytools")); //add our meters
+
+builder.Services.AddSingleton<GifyMetrics>();
 
 //Run pipeline
 var appDbConnectionString = builder.Configuration.GetConnectionString("AppDbContextConnection");


### PR DESCRIPTION
For better observability I added logging, tracing and metrics to the app. You can hook them up to something like Grafana or the Aspire standalone dashboard to have a better overview of how your app behaves. You can also export them to Jaeger and Prometheus for longer term storage of your logs. 
My additions are only examples and can be extended in various ways.

Hope you find this helpful!